### PR TITLE
fix: disable persist-credentials to enable GitHub App authentication

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
**CRITICAL FIX**: Resolves GitHub App repository ruleset bypass issue based on web research.

## Problem
Badge automation was failing with repository rule violations despite correct GitHub App configuration. Web research revealed that `actions/checkout` with `persist-credentials: true` was persisting the default GITHUB_TOKEN in git config, overriding our GitHub App token.

## Solution
Set `persist-credentials: false` in the checkout step to prevent token persistence conflicts.

## Research References
- GitHub Community Discussion: https://github.com/orgs/community/discussions/72173
- Stack Overflow: https://stackoverflow.com/questions/77433427/why-do-bypass-settings-in-github-actions-rulesets-not-apply

## Expected Result
With this fix, the badge automation should work end-to-end:
1. ✅ GitHub App token will be properly recognized
2. ✅ Repository ruleset bypass will work correctly
3. ✅ Badge commits will succeed with 'Badge Automation Bot' attribution
4. ✅ Main branch will achieve green status on Actions/Checks

This should be the final fix needed for complete badge automation functionality.